### PR TITLE
feat: deprecate deepaas-predict

### DIFF
--- a/deepaas/cmd/execute.py
+++ b/deepaas/cmd/execute.py
@@ -18,6 +18,7 @@ import mimetypes
 import os
 import shutil
 import sys
+import warnings
 
 from oslo_config import cfg
 from oslo_log import log
@@ -111,6 +112,14 @@ def prediction(input_file, file_type, content_type):
 
 
 def main():
+    msg = (
+        "\033[0;31;40mWARNING: This command is deprectated, please use "
+        "deepaas-cli instead. \n"
+        "WARNING: This command will be removed in the next major release. \033[0m"
+    )
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    sys.stderr.write(msg + "\n")
+
     cfg.CONF(sys.argv[1:])
     input_file = CONF.input_file
     content_type = CONF.content_type

--- a/releasenotes/notes/deprecate-deepaas-predict-f92939d443cb1904.yaml
+++ b/releasenotes/notes/deprecate-deepaas-predict-f92939d443cb1904.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    The command ``deepaas-predict`` is now deprecated, please use ``deepaas-cli`` instead.


### PR DESCRIPTION
Functionality relies on a method predict_data() that was deprecated long ago. deepaas-cli already supports that functionality.

Fixes #154