### PR TITLE
fix: do not pass basePath to aiohttp_apispec

### DIFF
--- a/deepaas/api/__init__.py
+++ b/deepaas/api/__init__.py
@@ -103,6 +103,7 @@ async def get_app(
     if swagger:
         doc = str(pathlib.Path(base_path + doc))
         swagger = str(pathlib.Path(base_path + "/swagger.json"))
+        static_path = str(pathlib.Path(base_path + static_path))
 
         # init docs with all parameters, usual for ApiSpec
         aiohttp_apispec.setup_aiohttp_apispec(

--- a/deepaas/api/__init__.py
+++ b/deepaas/api/__init__.py
@@ -115,7 +115,6 @@ async def get_app(
                 "description": "API documentation",
                 "url": "https://deepaas.readthedocs.org/",
             },
-            basePath=base_path,
             version=deepaas.extract_version(),
             url=swagger,
             swagger_path=doc if enable_doc else None,


### PR DESCRIPTION
Passing the basePath to the aiohttp_apispec.setup_aiohttp_apispec method caused that URL that were used from the Swagger UI added the path twice, resulting in 404 not found methods.

Fixes #111