### PR TITLE
docs: update entry point configuration from setup.cfg to pyproject.toml

### DIFF
--- a/doc/source/user/v2-api.rst
+++ b/doc/source/user/v2-api.rst
@@ -25,14 +25,12 @@ one will be served.
 
 In order to define your entry points, your module should leverage setuptools and be
 ready to be installed in the system. Then, in order to define your entry points, you
-should add the following to your ``setup.cfg`` configuration file:
+should add the following to your ``pyproject.toml`` configuration file:
 
-.. code-block:: ini
+.. code-block:: toml
 
-   [entry_points]
-
-   deepaas.v2.model =
-       my_model = package_name.module
+   [project.entry-points."deepaas.v2.model"]
+   my_model = package_name.module
 
 This will define an entry point in the ``deepaas.v2.model`` namespace, called
 ``my_model``. All the required functionality will be fetched from the
@@ -42,12 +40,10 @@ This will define an entry point in the ``deepaas.v2.model`` namespace, called
 If you provide a class with the required functionality, the entry point will be
 defined as follows:
 
-.. code-block:: ini
+.. code-block:: toml
 
-   [entry_points]
-
-   deepaas.v2.model =
-       my_model = package_name.module:Class
+   [project.entry-points."deepaas.v2.model"]
+   my_model = package_name.module:Class
 
 Again, this will define an entry point in the ``deepaas.v2.model`` namespace,
 called ``my_model``. All the required functionality will be fetched


### PR DESCRIPTION
Fixes # (issue)

This pull request includes updates to the documentation to reflect changes in the configuration file format used for defining entry points. The most important changes are:

* [`doc/source/user/v2-api.rst`](diffhunk://#diff-04be3c9657e04be9625075747e788053cc5f361f20d39f20632ef58317ca88a0L28-R32): Updated instructions to use `pyproject.toml` instead of `setup.cfg` for defining entry points.
* [`doc/source/user/v2-api.rst`](diffhunk://#diff-04be3c9657e04be9625075747e788053cc5f361f20d39f20632ef58317ca88a0L45-R45): Changed code block examples from `ini` to `toml` format to match the new configuration file.# Description


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] This change is a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
